### PR TITLE
Upgrade dependencies

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -266,7 +266,7 @@ packages:
       name: dbus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.8"
   device_info:
     dependency: "direct main"
     description:
@@ -343,7 +343,7 @@ packages:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.1"
   file:
     dependency: transitive
     description:
@@ -357,7 +357,7 @@ packages:
       name: file_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.6.1"
+    version: "5.2.4"
   fixnum:
     dependency: transitive
     description:
@@ -504,9 +504,11 @@ packages:
   flutter_sodium:
     dependency: "direct main"
     description:
-      name: flutter_sodium
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: HEAD
+      resolved-ref: "267435eaf07af60b94406adf14bedf21e08a6b4f"
+      url: "https://github.com/ente-io/flutter_sodium.git"
+    source: git
     version: "0.2.0"
   flutter_speed_dial:
     dependency: "direct main"
@@ -741,7 +743,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.3+1"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -776,7 +778,7 @@ packages:
       name: package_info_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.1.0"
   password_strength:
     dependency: "direct main"
     description:
@@ -853,7 +855,7 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.1.3"
   petitparser:
     dependency: transitive
     description:
@@ -1327,7 +1329,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "3.1.2"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   event_bus: ^2.0.0
   expandable: ^5.0.1
   expansion_tile_card: ^2.0.0
-  file_picker: ^4.6.1
+  file_picker: ^5.2.4
   fk_user_agent: ^2.1.0
   flutter:
     sdk: flutter
@@ -38,7 +38,9 @@ dependencies:
   flutter_native_splash: ^2.2.13
   flutter_secure_storage: ^6.0.0
   flutter_slidable: ^2.0.0
-  flutter_sodium: ^0.2.0
+  flutter_sodium:
+    git:
+      url: https://github.com/ente-io/flutter_sodium.git
   flutter_speed_dial: ^6.2.0
   flutter_windowmanager: ^0.2.0
   fluttertoast: ^8.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ente_auth
 description: ente two-factor authenticator
-version: 1.0.21+21
+version: 1.0.22+22
 publish_to: none
 
 environment:


### PR DESCRIPTION
## Description

Upgrade `file_picker` to fix the issue on Android 13 where the import dialog was not popping up due to permission issues.

This PR also upgrades `flutter_sodium` to use ffi 2.0.0+, as it was causing conflicts while resolving dependencies.

Fixes https://github.com/ente-io/auth/issues/4.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [x] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
