### PR TITLE
Update warning dialog when "Hide from recents" is enabled

### DIFF
--- a/lib/ui/settings/security_section_widget.dart
+++ b/lib/ui/settings/security_section_widget.dart
@@ -90,7 +90,7 @@ class _SecuritySectionWidgetState extends State<SecuritySectionWidget> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: const [
                           Text(
-                            "Hiding from the task switcher will prevent you from taking screenshots in this app.",
+                            "Hiding from the task switcher may prevent you from taking screenshots in this app.",
                             style: TextStyle(
                               height: 1.5,
                             ),


### PR DESCRIPTION
## Description

Not all ROMs may block capturing of screenshots once FLAG_SECURE is set, so update the copy to reflect the same

Fixes #18.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
