### PR TITLE
Run the CLA bot only on comments to PR

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
     CLAAssistant:
+        # This job only runs for pull request comments
+        if: ${{ github.event.issue.pull_request }}
         runs-on: ubuntu-latest
         steps:
             - name: "CLA Assistant"


### PR DESCRIPTION
Right now, it unnecessarily runs and sends an email when customers open issues.

Not tested, but can test it by opening an issue after this is merged.

Reference:
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment
