### PR TITLE
Fix the crash on opening change email dialog

### DIFF
--- a/lib/ui/tools/app_lock.dart
+++ b/lib/ui/tools/app_lock.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// A widget which handles app lifecycle events for showing and hiding a lock screen.
 /// This should wrap around a `MyApp` widget (or equivalent).
@@ -107,6 +108,8 @@ class _AppLockState extends State<AppLock> with WidgetsBindingObserver {
       themeMode: ThemeMode.system,
       theme: widget.lightTheme,
       darkTheme: widget.darkTheme,
+      supportedLocales: AppLocalizations.supportedLocales,
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
       onGenerateRoute: (settings) {
         switch (settings.name) {
           case '/lock-screen':


### PR DESCRIPTION
The crash was happening in the `context.l10n` line in the change_email_dialog.dart. This was because the root MaterialApp created by AppLock wasn't being passed the AppLocalizations object.

Tested:
- Was able to reproduce the crash on iOS simulator (null check assertion)
- After the change, the crash doesn't happen