### PR TITLE
Use `AppLocalizations.localizationsDelegates` in other MaterialApp

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -79,12 +79,7 @@ class _AppState extends State<App> {
           darkTheme: dartTheme,
           debugShowCheckedModeBanner: false,
           supportedLocales: AppLocalizations.supportedLocales,
-          localizationsDelegates: const [
-            AppLocalizations.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-          ],
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
           routes: _getRoutes,
         ),
       );


### PR DESCRIPTION
Smoke tested by running the app on iOS simulator
