### PR TITLE
Increase trailing margin for the theme picker selection checkmark

### DIFF
--- a/lib/ui/components/menu_item_widget.dart
+++ b/lib/ui/components/menu_item_widget.dart
@@ -12,6 +12,9 @@ class MenuItemWidget extends StatefulWidget {
   final IconData? trailingIcon;
   final Widget? trailingSwitch;
   final bool trailingIconIsMuted;
+
+  /// If provided, add this much extra spacing to the right of the trailing icon.
+  final double trailingExtraMargin;
   final VoidCallback? onTap;
   final VoidCallback? onDoubleTap;
   final Color? menuItemColor;
@@ -27,6 +30,7 @@ class MenuItemWidget extends StatefulWidget {
     this.trailingIcon,
     this.trailingSwitch,
     this.trailingIconIsMuted = false,
+    this.trailingExtraMargin = 0.0,
     this.onTap,
     this.onDoubleTap,
     this.menuItemColor,
@@ -141,11 +145,15 @@ class _MenuItemWidgetState extends State<MenuItemWidget> {
                   ),
                 )
               : widget.trailingIcon != null
-                  ? Icon(
-                      widget.trailingIcon,
-                      color: widget.trailingIconIsMuted
-                          ? enteColorScheme.strokeMuted
-                          : null,
+                  ? Padding(
+                      padding:
+                          EdgeInsets.only(right: widget.trailingExtraMargin),
+                      child: Icon(
+                        widget.trailingIcon,
+                        color: widget.trailingIconIsMuted
+                            ? enteColorScheme.strokeMuted
+                            : null,
+                      ),
                     )
                   : widget.trailingSwitch ?? const SizedBox.shrink(),
         ],

--- a/lib/ui/settings/theme_switch_widget.dart
+++ b/lib/ui/settings/theme_switch_widget.dart
@@ -73,6 +73,7 @@ class _ThemeSwitchWidgetState extends State<ThemeSwitchWidget> {
       pressedColor: getEnteColorScheme(context).fillFaint,
       isExpandable: false,
       trailingIcon: currentThemeMode == themeMode ? Icons.check : null,
+      trailingExtraMargin: 4,
       onTap: () async {
         AdaptiveTheme.of(context).setThemeMode(themeMode);
         currentThemeMode = themeMode;


### PR DESCRIPTION
Before this, the checkmark aligned to the dropdown indicators. This increases the spacing (to match that of the leading text) to indicate that the checkmark is part of the content.

Modified Figma also.

Before / After

<img width="950" alt="Screenshot 2023-01-08 at 4 31 15 PM" src="https://user-images.githubusercontent.com/24503581/211192495-cbe4f71e-c9aa-4bf0-98bb-cb5bc71e313c.png">
