### PR TITLE
Enable the BIS self classification flag

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -31,6 +31,8 @@
 		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>LSRequiresIPhoneOS</key>
 		<true/>
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 		<key>MinimumOSVersion</key>
 		<string>12.0</string>
 		<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
We've submitted the BIS self classification report for the auth app alongwith the photos app. More details: https://github.com/ente-io/photos-app/issues/427