### PR TITLE
Upload to Google Play from GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,69 +2,78 @@ name: Flutter CI
 
 # This workflow is triggered on pushes to the repository.
 on:
-  workflow_dispatch:
-    # Enable manual run
-  push:
-    # Sequence of patterns matched against refs/tags
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v4.2.0
+    workflow_dispatch:
+        # Enable manual run
+    push:
+        # Sequence of patterns matched against refs/tags
+        tags:
+            - "v*" # Push events to matching v*, i.e. v4.2.0
 
 jobs:
-  build:
-    # This job will run on ubuntu virtual machine
-    runs-on: ubuntu-latest
-    steps:
+    build:
+        # This job will run on ubuntu virtual machine
+        runs-on: ubuntu-latest
+        steps:
+            # Setup Java environment in order to build the Android app.
+            - uses: actions/checkout@v2
+            - uses: actions/setup-java@v2
+              with:
+                  distribution: "adopt"
+                  java-version: "11"
 
-      # Setup Java environment in order to build the Android app.
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
-        with:
-          distribution: 'adopt'
-          java-version: '11'
+            # Setup the flutter environment.
+            - uses: subosito/flutter-action@v2
+              with:
+                  channel: "stable"
+                  flutter-version: "3.3.8"
 
-      # Setup the flutter environment.
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          flutter-version: '3.3.8'
+            # Fetch sub modules
+            - run: git submodule update --init --recursive
 
-      # Fetch sub modules
-      - run: git submodule update --init --recursive
+            # Get flutter dependencies.
+            - run: flutter pub get
 
-      # Get flutter dependencies.
-      - run: flutter pub get
+            - name: Setup keys
+              uses: timheuer/base64-to-file@v1
+              with:
+                  fileName: "keystore/ente_auth_key.jks"
+                  encodedString: ${{ secrets.SIGNING_KEY }}
 
-      - name: Setup keys
-        uses: timheuer/base64-to-file@v1
-        with:
-          fileName: 'keystore/ente_auth_key.jks'
-          encodedString: ${{ secrets.SIGNING_KEY }}
+            # Build independent apk.
+            - name: Build
+              run: flutter build apk --release --flavor independent && mv build/app/outputs/flutter-apk/app-independent-release.apk build/app/outputs/flutter-apk/ente-auth.apk
+              env:
+                  SIGNING_KEY_PATH: "/home/runner/work/_temp/keystore/ente_auth_key.jks"
+                  SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+                  SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+                  SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
 
-      # Build independent apk.
-      - name: Build
-        run: flutter build apk --release --flavor independent && mv build/app/outputs/flutter-apk/app-independent-release.apk build/app/outputs/flutter-apk/ente-auth.apk
-        env:
-          SIGNING_KEY_PATH: '/home/runner/work/_temp/keystore/ente_auth_key.jks'
-          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+            - name: Checksum
+              run: sha256sum build/app/outputs/flutter-apk/ente-auth.apk > build/app/outputs/flutter-apk/sha256sum
 
-      - name: Checksum
-        run: sha256sum build/app/outputs/flutter-apk/ente-auth.apk > build/app/outputs/flutter-apk/sha256sum
+            # Upload generated apk to the artifacts.
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: release-apk
+                  path: build/app/outputs/flutter-apk/ente-auth.apk
 
-      # Upload generated apk to the artifacts.
-      - uses: actions/upload-artifact@v2
-        with:
-          name: release-apk
-          path: build/app/outputs/flutter-apk/ente-auth.apk
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: release-checksum
+                  path: build/app/outputs/flutter-apk/sha256sum
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: release-checksum
-          path: build/app/outputs/flutter-apk/sha256sum
+            # Create a Github release
+            - uses: ncipollo/release-action@v1
+              with:
+                  artifacts: "build/app/outputs/flutter-apk/ente-auth.apk,build/app/outputs/flutter-apk/sha256sum"
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Create a Github release
-      - uses: ncipollo/release-action@v1
-        with:
-          artifacts: "build/app/outputs/flutter-apk/ente-auth.apk,build/app/outputs/flutter-apk/sha256sum"
-          token: ${{ secrets.GITHUB_TOKEN }}
+            # Upload to Play store
+            - uses: ente/upload-google-play@v1
+              with:
+                  serviceAccountJsonPlainText: ${{ SERVICE_ACCOUNT_JSON }}
+                  packageName: io.ente.auth
+                  releaseFiles: build/app/outputs/flutter-apk/ente-auth.apk
+                  track: internal
+                  #mappingFile: app/build/outputs/mapping/release/mapping.txt
+                  #debugSymbols: app/intermediates/merged_native_libs/release/out/lib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
                   token: ${{ secrets.GITHUB_TOKEN }}
 
             # Upload to Play store
-            - uses: ente/upload-google-play@v1
+            - uses: ente-io/upload-google-play@v1
               with:
                   serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
                   packageName: io.ente.auth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,5 +84,3 @@ jobs:
                   packageName: io.ente.auth
                   releaseFiles: build/app/outputs/flutter-apk/ente-auth.aab
                   track: internal
-                  mappingFile: build/app/outputs/mapping/playstoreRelease/mapping.txt
-                  debugSymbols: build/app/intermediates/merged_native_libs/playstoreRelease/out/lib/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
             # Build Play store aab.
             - name: Build
-              run: flutter build appbundle --release --flavor playstore && mv build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab build/app/outputs/flutter-apk/ente-auth.aab
+              run: flutter build appbundle --release --flavor playstore
               env:
                   SIGNING_KEY_PATH: "/home/runner/work/_temp/keystore/ente_auth_key.jks"
                   SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
@@ -82,5 +82,5 @@ jobs:
               with:
                   serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
                   packageName: io.ente.auth
-                  releaseFiles: build/app/outputs/flutter-apk/ente-auth.aab
+                  releaseFiles: build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab
                   track: internal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,15 @@ jobs:
                   SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
                   SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
 
+            # Build Play store aab.
+            - name: Build
+              run: flutter build appbundle --release --flavor playstore && mv build/app/outputs/bundle/playstoreRelease/app-playstore-release.aab build/app/outputs/flutter-apk/ente-auth.aab
+              env:
+                  SIGNING_KEY_PATH: "/home/runner/work/_temp/keystore/ente_auth_key.jks"
+                  SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+                  SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+                  SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+
             - name: Checksum
               run: sha256sum build/app/outputs/flutter-apk/ente-auth.apk > build/app/outputs/flutter-apk/sha256sum
 
@@ -71,9 +80,9 @@ jobs:
             # Upload to Play store
             - uses: ente/upload-google-play@v1
               with:
-                  serviceAccountJsonPlainText: ${{ SERVICE_ACCOUNT_JSON }}
+                  serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
                   packageName: io.ente.auth
-                  releaseFiles: build/app/outputs/flutter-apk/ente-auth.apk
+                  releaseFiles: build/app/outputs/flutter-apk/ente-auth.aab
                   track: internal
-                  #mappingFile: app/build/outputs/mapping/release/mapping.txt
-                  #debugSymbols: app/intermediates/merged_native_libs/release/out/lib
+                  mappingFile: build/app/outputs/mapping/playstoreRelease/mapping.txt
+                  debugSymbols: build/app/intermediates/merged_native_libs/playstoreRelease/out/lib/


### PR DESCRIPTION
- Forked the action to upload to Play store (ente-io/upload-google-play)
- Added an extra step in the ci.yaml to build an AAB
- Added an extra step in the ci.yaml to use the upload-google-play action to publish to the play store

Currently it pushes to the internal track, can configure it to push to production too

Tested it here (by running the action after disabling the Github release): https://github.com/ente-io/auth/actions/runs/4031138163