### PR TITLE
Resolve package version conflict and fix error

### DIFF
--- a/lib/utils/auth_util.dart
+++ b/lib/utils/auth_util.dart
@@ -1,5 +1,5 @@
-import 'package:local_auth/auth_strings.dart';
 import 'package:local_auth/local_auth.dart';
+import 'package:local_auth_android/local_auth_android.dart';
 import 'package:logging/logging.dart';
 
 Future<bool> requestAuthentication(String reason) async {
@@ -7,18 +7,20 @@ Future<bool> requestAuthentication(String reason) async {
   await LocalAuthentication().stopAuthentication();
   return await LocalAuthentication().authenticate(
     localizedReason: reason,
-    androidAuthStrings: const AndroidAuthMessages(
-      biometricHint: "Verify identity",
-      biometricNotRecognized: "Not recognized, try again",
-      biometricRequiredTitle: "Biometric required",
-      biometricSuccess: "Successfully verified",
-      cancelButton: "Cancel",
-      deviceCredentialsRequiredTitle: "Device credentials required",
-      deviceCredentialsSetupDescription: "Device credentials required",
-      goToSettingsButton: "Go to settings",
-      goToSettingsDescription:
-          "Authentication is not setup on your device, go to Settings > Security to set it up",
-      signInTitle: "Authentication required",
-    ),
+    authMessages: [
+      const AndroidAuthMessages(
+        biometricHint: "Verify identity",
+        biometricNotRecognized: "Not recognized, try again",
+        biometricRequiredTitle: "Biometric required",
+        biometricSuccess: "Successfully verified",
+        cancelButton: "Cancel",
+        deviceCredentialsRequiredTitle: "Device credentials required",
+        deviceCredentialsSetupDescription: "Device credentials required",
+        goToSettingsButton: "Go to settings",
+        goToSettingsDescription:
+            "Authentication is not setup on your device, go to Settings > Security to set it up",
+        signInTitle: "Authentication required",
+      ),
+    ],
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.40+40
 publish_to: none
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
   adaptive_theme: ^3.1.0 # done
@@ -44,9 +44,9 @@ dependencies:
   fluttertoast: ^8.1.1
   google_nav_bar: ^5.0.5 #supported
   http: ^0.13.4
-  intl: ^0.17.0
+  intl: ^0.18.0
   json_annotation: ^4.5.0
-  local_auth: ^1.1.5
+  local_auth: ^2.1.3
   logging: ^1.0.1
   modal_bottom_sheet: ^3.0.0-pre
   move_to_background: ^1.0.2
@@ -76,7 +76,6 @@ dev_dependencies:
   json_serializable: ^6.2.0
   lints: ^1.0.1
   mocktail: ^0.3.0
-
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
## Changes
- intl package has been updated from 1.17.0 to 1.18.0
- local_auth package has been updated from 1.1.5 to 2.1.3 
- Code related to the local_auth package has been updated

## Description

With the recent update of the `local_auth` package to version 2.1.3, the `androidAuthStrings` property has been deprecated. Instead, a new property called `authMessages` has been introduced, which expects an Iterable of type AuthMessages as input.

To utilize the `AndroidAuthMessages` class, we need to import platform-specific extensions. [Link](https://github.com/flutter/flutter/issues/102164)


**This pull request addresses the following error.**
```
Resolving dependencies... (18.3s)
Because local_auth >=1.1.0 <2.1.3 depends on intl ^0.17.0 and ente_auth depends on intl ^0.18.0, local_auth
  >=1.1.0 <2.1.3 is forbidden.
So, because ente_auth depends on local_auth ^1.1.5, version solving failed.

```

### Package Version Changes
```diff
- intl: ^1.17.0
+ intl: ^1.18.0
```

```diff
- local_auth: ^1.1.5
+ local_auth: ^2.1.3 
```
