### PR TITLE
Update _getProviderTitle to also split on parentheses

### DIFF
--- a/lib/ui/utils/icon_utils.dart
+++ b/lib/ui/utils/icon_utils.dart
@@ -65,6 +65,6 @@ class IconUtils {
   }
 
   String _getProviderTitle(String provider) {
-    return provider.split(".")[0].toLowerCase();
+    return provider.split(RegExp(r'[.(]'))[0].trim().toLowerCase();
   }
 }


### PR DESCRIPTION
## Description

I sometimes put extra information between parentheses in the title, and I noticed icons weren't loading for these items. So it would load for "Discord" but not "Discord (old account)". 
 
This is because the title string was only split on dots, so parentheses were included in searched for icons and then prevented the icons from being found. This simple change should fix that.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
