### PR TITLE
Add missing slugs to titles with space

### DIFF
--- a/assets/custom-icons/_data/custom-icons.json
+++ b/assets/custom-icons/_data/custom-icons.json
@@ -34,6 +34,7 @@
     },
     {
       "title": "Control D",
+      "slug": "controld",
       "hex": "5FD800"
     },
     {
@@ -83,9 +84,9 @@
       "title": "KuCoin",
       "hex": "01BC8D"
     },
-	{
+	  {
       "title": "La Poste",
-	  "slug": "laposte"
+	    "slug": "laposte"
     },
     {
       "title": "Microsoft"
@@ -126,10 +127,12 @@
       "color": "EF8300"
     },
     {
-      "title": "Privacy Guides"
+      "title": "Privacy Guides",
+      "slug": "privacyguides"
     },
     {
-      "title": "Privacy.com"
+      "title": "Privacy.com",
+      "slug": "privacy"
     },
     {
       "title": "Proton"
@@ -143,6 +146,7 @@
     },
     {
       "title": "Standard Notes",
+      "slug": "standardnotes",
       "hex": "2173E6"
     },
     {
@@ -154,6 +158,7 @@
     },
     {
       "title": "Trading 212",
+      "slug": "trading212",
       "hex": "4BA4DE"
     },
     {


### PR DESCRIPTION


## Description
Added slugs to a few items where the title contained a space. The icons are currently not showing for those items in the app, adding the slug will probably fix it.
 
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] 🖼️ New icon
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
