### PR TITLE
fix: bitwarden imports

### DIFF
--- a/lib/ui/settings/data/import/bitwarden_import.dart
+++ b/lib/ui/settings/data/import/bitwarden_import.dart
@@ -60,7 +60,7 @@ Future<void> _pickBitwardenJsonFile(BuildContext context) async {
     if (count != null) {
       await importSuccessDialog(context, count);
     }
-  } catch (e, stacktrace) {
+  } catch (e) {
     await progressDialog.hide();
     await showErrorDialog(
       context,

--- a/lib/ui/settings/data/import/bitwarden_import.dart
+++ b/lib/ui/settings/data/import/bitwarden_import.dart
@@ -60,7 +60,7 @@ Future<void> _pickBitwardenJsonFile(BuildContext context) async {
     if (count != null) {
       await importSuccessDialog(context, count);
     }
-  } catch (e) {
+  } catch (e, stacktrace) {
     await progressDialog.hide();
     await showErrorDialog(
       context,
@@ -80,18 +80,25 @@ Future<int?> _processBitwardenExportFile(
   List<dynamic> jsonArray = data['items'];
   final parsedCodes = [];
   for (var item in jsonArray) {
-    if (item['login']['totp'] != null) {
-      var issuer = item['name'];
-      var account = item['login']['username'];
-      var secret = item['login']['totp'];
+    if (item['login'] != null && item['login']['totp'] != null) {
+      var totp = item['login']['totp'];
 
-      parsedCodes.add(
-        Code.fromAccountAndSecret(
+      Code code;
+
+      if (totp.contains("otpauth://")) {
+        code = Code.fromRawData(totp);
+      } else {
+        var issuer = item['name'];
+        var account = item['login']['username'];
+
+        code = Code.fromAccountAndSecret(
           account,
           issuer,
-          secret,
-        ),
-      );
+          totp,
+        );
+      }
+
+      parsedCodes.add(code);
     }
   }
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

There are two issues with Bitwarden imports ATM:

1. TOTP secrets in Bitwarden are sometimes saved in a format of `otpauth://[...]` and sometimes in a format of secret only. Ente auth assumes that only the second one is used, which is not true and causes an exception. To make both methods work as excepted, in the code, I'm checking which format is used and create `Code` object accordingly.
2. Sometimes items in Bitwarden exports are not accounts, but rather notes. In that case, the `item` variable in the `_processBitwardenExportFile` method does not contain the `login` attribute, which causes an exception. I've added a check to make sure that the item we're parsing is indeed an account.

It is my first time making something in Dart, so please don't be too harsh about my code :)

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] 🖼️ New icon
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
