### PR TITLE
Fix privacy screen colors

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -41,8 +41,8 @@ analyzer:
     use_rethrow_when_possible: info
     require_trailing_commas: error
 
-    prefer_const_constructors: error # too many warnings
-    prefer_const_declarations: error # too many warnings
+    prefer_const_constructors: warning
+    prefer_const_declarations: warning
     prefer_const_constructors_in_immutables: ignore # too many warnings
 
     avoid_renaming_method_parameters: ignore # incorrect warnings for `equals` overrides

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -216,12 +216,12 @@ SPEC CHECKSUMS:
   fk_user_agent: 1f47ec39291e8372b1d692b50084b0d54103c545
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_email_sender: 02d7443217d8c41483223627972bfdc09f74276b
-  flutter_inappwebview: bfd58618f49dc62f2676de690fc6dcda1d6c3721
+  flutter_inappwebview: acd4fc0f012cefd09015000c241137d82f01ba62
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_native_splash: 52501b97d1c0a5f898d687f1646226c1f93c56ef
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   flutter_sodium: c84426b4de738514b5b66cfdeb8a06634e72fe0b
-  fluttertoast: fafc4fa4d01a6a9e4f772ecd190ffa525e9e2d9c
+  fluttertoast: 31b00dabfa7fb7bacd9e7dbee580d7a2ff4bf265
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   local_auth_ios: c6cf091ded637a88f24f86a8875d8b0f526e2605
   move_to_background: 39a5b79b26d577b0372cbe8a8c55e7aa9fcd3a2d
@@ -247,4 +247,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: b4e3a7eabb03395b66e81fc061789f61526ee6bb
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ente_auth
 description: ente two-factor authenticator
-version: 2.0.30+230
+version: 2.0.31+231
 publish_to: none
 
 environment:


### PR DESCRIPTION
### Description
Fixes this monstrosity.

<img width="320" alt="Screenshot 2024-01-06 at 10 17 28 PM" src="https://github.com/ente-io/auth/assets/1161789/30964804-8e7e-429b-b4f0-6963059c931b">
  
  
### Note
On iOS, the colors could still be inverted if the user has opted for a theme different from the system theme, since `LaunchImage` is dynamically provided by iOS