### PR TITLE
Fix inconsitent state

### DIFF
--- a/lib/ui/account/login_page.dart
+++ b/lib/ui/account/login_page.dart
@@ -62,6 +62,7 @@ class _LoginPageState extends State<LoginPage> {
         buttonText: context.l10n.logInLabel,
         onPressedFunction: () async {
           UserService.instance.setEmail(_email!);
+          Configuration.instance.resetVolatilePassword();
           SrpAttributes? attr;
           bool isEmailVerificationEnabled = true;
           try {
@@ -176,31 +177,33 @@ class _LoginPageState extends State<LoginPage> {
                               .copyWith(fontSize: 12),
                           tags: {
                             'u-terms': StyledTextActionTag(
-                              (String? text, Map<String?, String?> attrs) => Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (BuildContext context) {
-                                      return WebPage(
-                                        context.l10n.termsOfServicesTitle,
-                                        "https://ente.io/terms",
-                                      );
-                                    },
-                                  ),
+                              (String? text, Map<String?, String?> attrs) =>
+                                  Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (BuildContext context) {
+                                    return WebPage(
+                                      context.l10n.termsOfServicesTitle,
+                                      "https://ente.io/terms",
+                                    );
+                                  },
                                 ),
+                              ),
                               style: const TextStyle(
                                 decoration: TextDecoration.underline,
                               ),
                             ),
                             'u-policy': StyledTextActionTag(
-                              (String? text, Map<String?, String?> attrs) => Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (BuildContext context) {
-                                      return WebPage(
-                                        context.l10n.privacyPolicyTitle,
-                                        "https://ente.io/privacy",
-                                      );
-                                    },
-                                  ),
+                              (String? text, Map<String?, String?> attrs) =>
+                                  Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (BuildContext context) {
+                                    return WebPage(
+                                      context.l10n.privacyPolicyTitle,
+                                      "https://ente.io/privacy",
+                                    );
+                                  },
                                 ),
+                              ),
                               style: const TextStyle(
                                 decoration: TextDecoration.underline,
                               ),

--- a/lib/ui/settings/data/export_widget.dart
+++ b/lib/ui/settings/data/export_widget.dart
@@ -154,7 +154,7 @@ Future<void> _exportCodes(BuildContext context, String fileContent) async {
       sharePositionOrigin: Rect.fromLTWH(0, 0, size.width, size.height / 2),
     );
   }
-  Future.delayed(const Duration(seconds: 15), () async {
+  Future.delayed(const Duration(seconds: 30), () async {
     if (_codeFile.existsSync()) {
       _codeFile.deleteSync();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ente_auth
 description: ente two-factor authenticator
-version: 2.0.31+231
+version: 2.0.33+233
 publish_to: none
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ente_auth
 description: ente two-factor authenticator
-version: 2.0.33+233
+version: 2.0.34+234
 publish_to: none
 
 environment:


### PR DESCRIPTION
If user clicks on New user login flow, abandon that in between and tries account recovery via recovery code, we were using old volatile password in memory for generating the recovery_key for UI.

This PR fixes that issue.